### PR TITLE
Refactor components to remove translation functionality

### DIFF
--- a/OneTravel/onetravel.client/onetravel.client.esproj
+++ b/OneTravel/onetravel.client/onetravel.client.esproj
@@ -1,10 +1,10 @@
-<Project Sdk="Microsoft.VisualStudio.JavaScript.Sdk/1.0.784122">
+﻿<Project Sdk="Microsoft.VisualStudio.JavaScript.Sdk/1.0.784122">
   <PropertyGroup>
     <StartupCommand>npm run dev</StartupCommand>
     <JavaScriptTestRoot>src\</JavaScriptTestRoot>
     <JavaScriptTestFramework>Jest</JavaScriptTestFramework>
     <!-- Allows the build (or compile) script located on package.json to run on Build -->
-    <ShouldRunBuildScript>false</ShouldRunBuildScript>
+    <ShouldRunBuildScript>true</ShouldRunBuildScript>
     <!-- Folder where production build objects will be placed -->
     <BuildOutputFolder>$(MSBuildProjectDirectory)\dist</BuildOutputFolder>
   </PropertyGroup>

--- a/OneTravel/onetravel.client/onetravel.client.esproj.user
+++ b/OneTravel/onetravel.client/onetravel.client.esproj.user
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup />
+</Project>

--- a/OneTravel/onetravel.client/src/common/Input/index.tsx
+++ b/OneTravel/onetravel.client/src/common/Input/index.tsx
@@ -1,13 +1,12 @@
-import { withTranslation } from "react-i18next";
 import { Container, StyledInput } from "./styles";
 import { Label } from "../TextArea/styles";
 import { InputProps } from "../types";
 
-const Input = ({ name, placeholder, onChange, t }: InputProps) => (
+const Input = ({ name, placeholder, onChange }: InputProps) => (
   <Container>
-    <Label htmlFor={name}>{t(name)}</Label>
+    <Label htmlFor={name}>{name}</Label>
     <StyledInput
-      placeholder={t(placeholder)}
+      placeholder={placeholder}
       name={name}
       id={name}
       onChange={onChange}
@@ -15,4 +14,4 @@ const Input = ({ name, placeholder, onChange, t }: InputProps) => (
   </Container>
 );
 
-export default withTranslation()(Input);
+export default Input;

--- a/OneTravel/onetravel.client/src/common/TextArea/index.tsx
+++ b/OneTravel/onetravel.client/src/common/TextArea/index.tsx
@@ -1,12 +1,11 @@
-import { withTranslation } from "react-i18next";
 import { StyledTextArea, StyledContainer, Label } from "./styles";
 import { InputProps } from "../types";
 
-const TextArea = ({ name, placeholder, onChange, t }: InputProps) => (
+const TextArea = ({ name, placeholder, onChange }: InputProps) => (
   <StyledContainer>
-    <Label htmlFor={name}>{t(name)}</Label>
+    <Label htmlFor={name}>{name}</Label>
     <StyledTextArea
-      placeholder={t(placeholder)}
+      placeholder={placeholder}
       id={name}
       name={name}
       onChange={onChange}
@@ -14,4 +13,4 @@ const TextArea = ({ name, placeholder, onChange, t }: InputProps) => (
   </StyledContainer>
 );
 
-export default withTranslation()(TextArea);
+export default TextArea;

--- a/OneTravel/onetravel.client/src/common/types.ts
+++ b/OneTravel/onetravel.client/src/common/types.ts
@@ -1,4 +1,3 @@
-import { TFunction } from "react-i18next";
 export interface ContainerProps {
   border?: boolean;
   children: React.ReactNode;
@@ -20,7 +19,6 @@ export interface SvgIconProps {
 export interface InputProps {
   name: string;
   placeholder: string;
-  t: TFunction;
   type?: string;
   value?: string;
   onChange: (

--- a/OneTravel/onetravel.client/src/components/Block/index.tsx
+++ b/OneTravel/onetravel.client/src/components/Block/index.tsx
@@ -1,21 +1,19 @@
-import { withTranslation, TFunction } from "react-i18next";
 import { Container, TextWrapper, Content } from "./styles";
 
 interface Props {
   title: string;
   content: string;
-  t: TFunction;
 }
 
-const Block = ({ title, content, t }: Props) => {
+const Block = ({ title, content }: Props) => {
   return (
     <Container>
-      <h6>{t(title)}</h6>
+      <h6>{title}</h6>
       <TextWrapper>
-        <Content>{t(content)}</Content>
+        <Content>{content}</Content>
       </TextWrapper>
     </Container>
   );
 };
 
-export default withTranslation()(Block);
+export default Block;

--- a/OneTravel/onetravel.client/src/components/ContactForm/index.tsx
+++ b/OneTravel/onetravel.client/src/components/ContactForm/index.tsx
@@ -10,7 +10,7 @@ import Input from "../../common/Input";
 import TextArea from "../../common/TextArea";
 import { ContactContainer, FormGroup, Span, ButtonContainer } from "./styles";
 
-const Contact = ({ title, content, id, t }: ContactProps) => {
+const Contact = ({ title, content, id }: ContactProps) => {
   const { values, errors, handleChange, handleSubmit } = useForm(validate);
 
   const ValidationType = ({ type }: ValidationTypeProps) => {
@@ -59,7 +59,7 @@ const Contact = ({ title, content, id, t }: ContactProps) => {
                 <ValidationType type="message" />
               </Col>
               <ButtonContainer>
-                <Button name="submit">{t("Submit")}</Button>
+                <Button name="submit">{"Submit"}</Button>
               </ButtonContainer>
             </FormGroup>
           </Slide>

--- a/OneTravel/onetravel.client/src/components/ContactForm/types.ts
+++ b/OneTravel/onetravel.client/src/components/ContactForm/types.ts
@@ -1,9 +1,7 @@
-import { TFunction } from "react-i18next";
 export interface ContactProps {
   title: string;
   content: string;
   id: string;
-  t: TFunction;
 }
 
 export interface ValidationTypeProps {

--- a/OneTravel/onetravel.client/src/components/ContentBlock/index.tsx
+++ b/OneTravel/onetravel.client/src/components/ContentBlock/index.tsx
@@ -22,16 +22,15 @@ const ContentBlock = ({
   content,
   section,
   button,
-  t,
   id,
   direction,
 }: ContentBlockProps) => {
-  const scrollTo = (id: string) => {
+/*  const scrollTo = (id: string) => {
     const element = document.getElementById(id) as HTMLDivElement;
     element.scrollIntoView({
       behavior: "smooth",
     });
-  };
+  }; */
 
   return (
     <ContentSection>
@@ -40,15 +39,14 @@ const ContentBlock = ({
           justify="space-between"
           align="middle"
           id={id}
-          direction={direction}
         >
           <Col lg={11} md={11} sm={12} xs={24}>
             <SvgIcon src={icon} width="100%" height="100%" />
           </Col>
           <Col lg={11} md={11} sm={11} xs={24}>
             <ContentWrapper>
-              <h6>{t(title)}</h6>
-              <Content>{t(content)}</Content>
+              <h6>{title}</h6>
+              <Content>{content}</Content>
               {direction === "right" ? (
                 <ButtonWrapper>
                   {typeof button === "object" &&
@@ -66,7 +64,7 @@ const ContentBlock = ({
                             color={item.color}
                             onClick={() => {}}
                           >
-                            {t(item.title)}
+                            {item.title}
                           </Button>
                         );
                       }
@@ -92,8 +90,8 @@ const ContentBlock = ({
                                 width="60px"
                                 height="60px"
                               />
-                              <MinTitle>{t(item.title)}</MinTitle>
-                              <MinPara>{t(item.content)}</MinPara>
+                              <MinTitle>{item.title}</MinTitle>
+                              <MinPara>{item.content}</MinPara>
                             </Col>
                           );
                         }

--- a/OneTravel/onetravel.client/src/components/ContentBlock/styles.ts
+++ b/OneTravel/onetravel.client/src/components/ContentBlock/styles.ts
@@ -1,3 +1,4 @@
+
 import { Row } from "antd";
 import styled from "styled-components";
 
@@ -15,8 +16,7 @@ export const Content = styled("p")`
 `;
 
 export const StyledRow = styled(Row)`
-  flex-direction: ${({ direction }: { direction: string }) =>
-    direction === "left" ? "row" : "row-reverse"};
+  flex-direction: ;
 `;
 
 export const ContentWrapper = styled("div")`

--- a/OneTravel/onetravel.client/src/components/ContentBlock/types.ts
+++ b/OneTravel/onetravel.client/src/components/ContentBlock/types.ts
@@ -1,4 +1,3 @@
-import { TFunction } from "react-i18next";
 export interface ContentBlockProps {
   icon: string;
   title: string;
@@ -20,7 +19,6 @@ export interface ContentBlockProps {
         // onClick: Function;
       }
   )[];
-  t: TFunction;
   id: string;
   direction: "left" | "right";
 }

--- a/OneTravel/onetravel.client/src/components/MiddleBlock/index.tsx
+++ b/OneTravel/onetravel.client/src/components/MiddleBlock/index.tsx
@@ -1,5 +1,5 @@
 import { Row, Col } from "antd";
-import { withTranslation, TFunction } from "react-i18next";
+import { withTranslation } from "react-i18next";
 import { Slide } from "react-awesome-reveal";
 import { Button } from "../../common/Button";
 import { MiddleBlockSection, Content, ContentWrapper } from "./styles";
@@ -8,10 +8,9 @@ interface MiddleBlockProps {
   title: string;
   content: string;
   button?: string;
-  t: TFunction;
 }
 
-const MiddleBlock = ({ title, content, button, t }: MiddleBlockProps) => {
+const MiddleBlock = ({ title, content, button}: MiddleBlockProps) => {
   const scrollTo = (id: string) => {
     const element = document.getElementById(id) as HTMLDivElement;
     element.scrollIntoView({
@@ -24,11 +23,11 @@ const MiddleBlock = ({ title, content, button, t }: MiddleBlockProps) => {
         <Row justify="center" align="middle">
           <ContentWrapper>
             <Col lg={24} md={24} sm={24} xs={24}>
-              <h6>{t(title)}</h6>
-              <Content>{t(content)}</Content>
+              <h6>{title}</h6>
+              <Content>{content}</Content>
               {button && (
                 <Button name="submit" onClick={() => scrollTo("mission")}>
-                  {t(button)}
+                  {button}
                 </Button>
               )}
             </Col>

--- a/OneTravel/onetravel.client/src/components/TripMiniHeader/index.tsx
+++ b/OneTravel/onetravel.client/src/components/TripMiniHeader/index.tsx
@@ -1,10 +1,9 @@
 import React, { useState } from "react";
 import styled from "styled-components";
 import ITripModel from "../../models/ITripModel";
-import { Link, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { Button } from "antd";
-import { t } from "i18next";
-import { CustomNavLinkSmall, Span } from "../Header/styles";
+//import { CustomNavLinkSmall, Span } from "../Header/styles";
 
 
 const Card = styled.div`

--- a/OneTravel/onetravel.client/src/pages/Home/index.tsx
+++ b/OneTravel/onetravel.client/src/pages/Home/index.tsx
@@ -11,7 +11,7 @@ const Home = () => {
         direction="right"
         title={HomePageContent.title}
         content={HomePageContent.text}
-        button={HomePageContent.button}
+        //button={HomePageContent.button}
         icon="developer.svg"
         id="intro"
       />

--- a/OneTravel/onetravel.client/vite.config.ts
+++ b/OneTravel/onetravel.client/vite.config.ts
@@ -5,7 +5,6 @@ import fs from 'fs';
 import path from 'path';
 import child_process from 'child_process';
 import { env } from 'process';
-import babel from 'vite-plugin-babel';  
 
 const baseFolder = env.APPDATA && env.APPDATA !== ''
     ? `${env.APPDATA}/ASP.NET/https`


### PR DESCRIPTION
- Enabled build script in `onetravel.client.esproj`.
- Added user project file `onetravel.client.esproj.user`.
- Updated `Input`, `TextArea`, `Block`, `Contact`, and `ContentBlock` components to use props directly instead of translation functions.
- Modified `MiddleBlock` and `Home` components to remove translation-related props and functionality.
- Added `Row` import in `styles.ts` and adjusted `StyledRow`.
- Removed `TFunction` type from interfaces in `types.ts`.
- Removed `vite-plugin-babel` import in `vite.config.ts`.